### PR TITLE
fix: add type shims for export tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,12 @@ Modular TypeScript toolkit for building deterministic, audio-reactive 2D video l
 ## Scripts
 
 ```bash
-npm run dev      # Launch the PixiJS realtime preview via Vite
-npm run render   # Run Puppeteer deterministic renderer
-npm run export   # Convert PNG sequences to mp4 via ffmpeg
-npm run analyze  # Offline Meyda FFT analysis helper
+npm run dev       # Launch the PixiJS realtime preview via Vite
+npm run render    # Run Puppeteer deterministic renderer
+npm run export    # Convert PNG sequences to mp4 via ffmpeg
+npm run analyze   # Offline Meyda FFT analysis helper
+npm run compare   # Compare rendered frames against a baseline with diff outputs
+npm run pipeline  # Render frames, encode video and emit a release manifest
 ```
 
 ## Development
@@ -31,3 +33,26 @@ npm run analyze  # Offline Meyda FFT analysis helper
 - Puppeteer is configured with GPU flags for headless WebGL2 support.
 
 Add new plugins by implementing the `VisPlugin` interface in `@vis/core` and registering it on the `VisEngine` instance.
+
+## Step-by-step workflow (що робити далі)
+
+1. **Install dependencies** – run `npm install` once to fetch workspace packages.
+2. **Build core packages** – execute `npm run build --workspaces` so shared libraries compile before running apps.
+3. **Launch realtime preview** – start the Vite-powered PixiJS preview with `npm run dev` and open the provided URL in the browser to iterate on visuals.
+4. **Iterate on plugins and presets** – edit files in `packages/` or `apps/` while the dev server hot-reloads changes.
+5. **Run deterministic renders** – when satisfied with a loop, call `npm run render` to generate a frame sequence using the headless renderer.
+6. **Export to video** – finish by converting the frame sequence into an `.mp4` using `npm run export`.
+7. **Analyze audio (optional)** – use `npm run analyze` to precompute FFT data for audio-reactive scenes.
+
+Following these steps ensures a repeatable pipeline from development through deterministic export.
+
+## Далі за планом
+
+8. **Контролюйте версію** – фіксуйте стабільні зміни в Git, створюйте тематичні гілки та синхронізуйте їх із CI перед запуском рендерингу на сервері.
+9. **Перевіряйте узгодженість кадрів** – використовуйте `npm run compare`, щоб автоматично звірити нові PNG із базовою послідовністю та за потреби отримати diff-кадри.
+10. **Оновлюйте аудіо-аналітику** – при змінах саундтреку повторно запускайте `npm run analyze`, кешуйте результат у репозиторії або CDN і підключайте через `@vis/audio`.
+11. **Оптимізуйте продуктивність** – профілюйте сцени через DevTools Performance/Memory, відключайте непотрібні плагіни та стежте за кількістю draw calls у PixiJS Inspector.
+12. **Автоматизуйте експорт** – скрипт `npm run pipeline` послідовно побудує кадри, збере `.mp4` та збереже `manifest.json` з метаданими loop-у.
+13. **Готуйте реліз** – додавайте артефакти з manifest-файлом, seed-ом, контрольними сумами та відео у каталозі preset-ів або реліз-нотах.
+
+Дотримання цих кроків допоможе довести цикл розробки від швидких ітерацій до надійних релізів без втрати детермінізму.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "npm run build --workspaces",
     "render": "tsx packages/export/src/cli/render.ts",
     "export": "tsx packages/export/src/cli/export-video.ts",
-    "analyze": "tsx packages/audio/src/cli/analyze.ts"
+    "analyze": "tsx packages/audio/src/cli/analyze.ts",
+    "compare": "tsx packages/export/src/cli/compare-frames.ts",
+    "pipeline": "tsx packages/export/src/cli/pipeline.ts"
   },
   "workspaces": [
     "packages/*",

--- a/packages/export/package.json
+++ b/packages/export/package.json
@@ -14,6 +14,8 @@
     "ffmpeg-static": "^5.2.0",
     "fluent-ffmpeg": "^2.1.2",
     "fs-extra": "^11.2.0",
+    "pixelmatch": "^5.3.0",
+    "pngjs": "^7.0.0",
     "puppeteer": "^22.8.0"
   },
   "peerDependencies": {

--- a/packages/export/src/cli/compare-frames.ts
+++ b/packages/export/src/cli/compare-frames.ts
@@ -1,0 +1,36 @@
+#!/usr/bin/env tsx
+import { compareFrameSequences } from "../index";
+
+const actualDir = process.argv[2] ?? "artifacts/frames";
+const baselineDir = process.argv[3] ?? "artifacts/baseline";
+const diffDir = process.argv[4];
+const thresholdArg = process.argv[5];
+const threshold = typeof thresholdArg === "string" ? Number(thresholdArg) : undefined;
+
+compareFrameSequences({ actualDir, baselineDir, diffDir, threshold })
+  .then((summary) => {
+    console.log(`Compared ${summary.totalCompared} frames.`);
+    if (summary.missingInActual.length > 0) {
+      console.warn(`Missing in actual: ${summary.missingInActual.join(", ")}`);
+    }
+    if (summary.missingInBaseline.length > 0) {
+      console.warn(`Missing in baseline: ${summary.missingInBaseline.join(", ")}`);
+    }
+    const formatted = summary.diffs
+      .filter((diff) => diff.mismatchRatio > 0)
+      .map((diff) => `${diff.frame} mismatch ${(diff.mismatchRatio * 100).toFixed(3)}%`);
+    if (formatted.length > 0) {
+      console.log(formatted.join("\n"));
+    }
+    console.log(`Max mismatch ${(summary.maxMismatch * 100).toFixed(3)}%, average ${(summary.averageMismatch * 100).toFixed(3)}%`);
+    if (threshold !== undefined && summary.maxMismatch > threshold) {
+      console.error(
+        `Frame mismatch ${summary.maxMismatch.toFixed(5)} exceeds threshold ${threshold.toFixed(5)}. Marking run as failed.`
+      );
+      process.exitCode = 1;
+    }
+  })
+  .catch((error) => {
+    console.error("Frame comparison failed", error);
+    process.exitCode = 1;
+  });

--- a/packages/export/src/cli/pipeline.ts
+++ b/packages/export/src/cli/pipeline.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env tsx
+import { join } from "path";
+import { runRenderAndEncode, writeReleaseManifest } from "../index";
+
+const entry = process.argv[2] ?? "apps/demo/dist/index.html";
+const outDir = process.argv[3] ?? "artifacts/frames";
+const totalFrames = Number(process.argv[4] ?? 360);
+const fps = Number(process.argv[5] ?? 60);
+const width = Number(process.argv[6] ?? 1080);
+const height = Number(process.argv[7] ?? 1920);
+const videoFile = process.argv[8] ?? join(outDir, "loop.mp4");
+const seed = process.argv[9] ?? "demo";
+
+runRenderAndEncode({ entry, outDir, totalFrames, fps, width, height, videoFile })
+  .then(async ({ frames, videoFile: renderedVideo }) => {
+    const manifestPath = join(outDir, "manifest.json");
+    await writeReleaseManifest({
+      frames,
+      videoFile: renderedVideo,
+      fps,
+      durationMs: (totalFrames / fps) * 1000,
+      seed,
+      outputPath: manifestPath,
+      plugins: ["@vis/renderer-pixi", "@vis/audio", "@vis/timeline"],
+    });
+    console.log(
+      `Rendered ${frames.length} frames to ${outDir}, encoded video at ${renderedVideo}, manifest saved to ${manifestPath}.`
+    );
+  })
+  .catch((error) => {
+    console.error("Pipeline run failed", error);
+    process.exitCode = 1;
+  });

--- a/packages/export/src/index.ts
+++ b/packages/export/src/index.ts
@@ -1,6 +1,11 @@
+import { createHash } from "crypto";
+import { createReadStream, createWriteStream } from "fs";
 import { mkdirp, pathExists } from "fs-extra";
-import { join, resolve } from "path";
+import { readdir, stat, writeFile, mkdir } from "fs/promises";
+import { join, resolve, relative, dirname } from "path";
 import { pathToFileURL } from "url";
+import { PNG } from "pngjs";
+import pixelmatch from "pixelmatch";
 import puppeteer from "puppeteer";
 import ffmpeg from "fluent-ffmpeg";
 import ffmpegStatic from "ffmpeg-static";
@@ -17,6 +22,19 @@ export interface OfflineRendererOptions {
 export interface FrameRenderResult {
   frame: number;
   path: string;
+}
+
+export interface RenderAndEncodeOptions extends OfflineRendererOptions {
+  videoFile?: string;
+  codec?: "libx264" | "prores_ks";
+  pixelFormat?: string;
+  framePattern?: string;
+}
+
+export interface RenderAndEncodeResult {
+  frames: FrameRenderResult[];
+  videoFile: string;
+  framePattern: string;
 }
 
 /**
@@ -60,6 +78,22 @@ export async function renderDeterministicFrames(options: OfflineRendererOptions)
   return results;
 }
 
+export async function runRenderAndEncode(options: RenderAndEncodeOptions): Promise<RenderAndEncodeResult> {
+  await ensureOutDir(options.outDir);
+  const frames = await renderDeterministicFrames(options);
+  const framePattern =
+    options.framePattern ?? inferFramePattern(frames, options.outDir) ?? join(options.outDir, "frame-%05d.png");
+  const videoFile = options.videoFile ?? join(options.outDir, "output.mp4");
+  await encodeVideo({
+    inputPattern: framePattern,
+    outputFile: videoFile,
+    fps: options.fps,
+    codec: options.codec,
+    pixelFormat: options.pixelFormat,
+  });
+  return { frames, videoFile, framePattern };
+}
+
 export interface ExportVideoOptions {
   inputPattern: string;
   outputFile: string;
@@ -72,12 +106,13 @@ export interface ExportVideoOptions {
  * Wraps ffmpeg invocation to build perfect mp4/prores loops from PNG sequences.
  */
 export async function encodeVideo(options: ExportVideoOptions): Promise<void> {
-  if (!ffmpegStatic) {
+  const binaryPath = ffmpegStatic;
+  if (binaryPath == null) {
     throw new Error("ffmpeg-static binary not found");
   }
   await new Promise<void>((resolvePromise, rejectPromise) => {
     ffmpeg()
-      .setFfmpegPath(ffmpegStatic)
+      .setFfmpegPath(binaryPath)
       .input(options.inputPattern)
       .inputOptions(["-framerate", options.fps.toString()])
       .videoCodec(options.codec ?? "libx264")
@@ -88,7 +123,7 @@ export async function encodeVideo(options: ExportVideoOptions): Promise<void> {
       ])
       .output(options.outputFile)
       .on("end", () => resolvePromise())
-      .on("error", (error) => rejectPromise(error))
+      .on("error", (error: Error) => rejectPromise(error))
       .run();
   });
 }
@@ -97,4 +132,203 @@ export async function ensureOutDir(path: string): Promise<void> {
   if (!(await pathExists(path))) {
     await mkdirp(path);
   }
+}
+
+export interface CompareFrameSequencesOptions {
+  actualDir: string;
+  baselineDir: string;
+  diffDir?: string;
+  threshold?: number;
+}
+
+export interface FrameMismatch {
+  frame: string;
+  diffPixels: number;
+  totalPixels: number;
+  mismatchRatio: number;
+  diffPath?: string;
+}
+
+export interface RegressionSummary {
+  diffs: FrameMismatch[];
+  totalCompared: number;
+  maxMismatch: number;
+  averageMismatch: number;
+  missingInActual: string[];
+  missingInBaseline: string[];
+}
+
+export async function compareFrameSequences(options: CompareFrameSequencesOptions): Promise<RegressionSummary> {
+  const [actualFiles, baselineFiles] = await Promise.all([
+    collectPngs(options.actualDir),
+    collectPngs(options.baselineDir),
+  ]);
+
+  const actualSet = new Set(actualFiles);
+  const baselineSet = new Set(baselineFiles);
+  const intersection = baselineFiles.filter((file) => actualSet.has(file));
+  const missingInActual = baselineFiles.filter((file) => !actualSet.has(file));
+  const missingInBaseline = actualFiles.filter((file) => !baselineSet.has(file));
+
+  const diffs: FrameMismatch[] = [];
+  if (options.diffDir) {
+    await mkdir(options.diffDir, { recursive: true });
+  }
+
+  for (const file of intersection) {
+    const baselinePath = join(options.baselineDir, file);
+    const actualPath = join(options.actualDir, file);
+    const [baselinePng, actualPng] = await Promise.all([readPng(baselinePath), readPng(actualPath)]);
+    if (baselinePng.width !== actualPng.width || baselinePng.height !== actualPng.height) {
+      throw new Error(`Frame size mismatch for ${file}`);
+    }
+    const diffPng = new PNG({ width: baselinePng.width, height: baselinePng.height });
+    const diffPixels = pixelmatch(
+      actualPng.data,
+      baselinePng.data,
+      diffPng.data,
+      baselinePng.width,
+      baselinePng.height,
+      {
+        threshold: options.threshold ?? 0.1,
+        includeAA: false,
+      }
+    );
+    let diffPath: string | undefined;
+    if (options.diffDir && diffPixels > 0) {
+      diffPath = join(options.diffDir, file);
+      await writePng(diffPng, diffPath);
+    }
+    const totalPixels = baselinePng.width * baselinePng.height;
+    diffs.push({
+      frame: file,
+      diffPixels,
+      totalPixels,
+      mismatchRatio: diffPixels / totalPixels,
+      diffPath,
+    });
+  }
+
+  const totalCompared = diffs.length;
+  const maxMismatch = totalCompared === 0 ? 0 : Math.max(...diffs.map((d) => d.mismatchRatio));
+  const averageMismatch =
+    totalCompared === 0 ? 0 : diffs.reduce((sum, diff) => sum + diff.mismatchRatio, 0) / totalCompared;
+
+  return { diffs, totalCompared, maxMismatch, averageMismatch, missingInActual, missingInBaseline };
+}
+
+export interface ReleaseManifestOptions {
+  frames: FrameRenderResult[];
+  videoFile: string;
+  fps: number;
+  durationMs: number;
+  seed: string;
+  outputPath: string;
+  plugins?: string[];
+  extra?: Record<string, unknown>;
+}
+
+export interface ReleaseManifest {
+  version: string;
+  generatedAt: string;
+  fps: number;
+  durationMs: number;
+  totalFrames: number;
+  seed: string;
+  video: {
+    path: string;
+    hash: string;
+    size: number;
+  };
+  frames: {
+    frame: number;
+    path: string;
+    hash: string;
+    size: number;
+  }[];
+  plugins?: string[];
+  extra?: Record<string, unknown>;
+}
+
+export async function writeReleaseManifest(options: ReleaseManifestOptions): Promise<ReleaseManifest> {
+  await ensureOutDir(dirname(options.outputPath));
+  const manifestDir = dirname(options.outputPath);
+  const frameEntries = [] as ReleaseManifest["frames"];
+  for (const frame of options.frames) {
+    const [hash, info] = await Promise.all([computeFileHash(frame.path), stat(frame.path)]);
+    frameEntries.push({
+      frame: frame.frame,
+      path: relative(manifestDir, frame.path),
+      hash,
+      size: info.size,
+    });
+  }
+  const videoInfo = await stat(options.videoFile);
+  const videoHash = await computeFileHash(options.videoFile);
+  const manifest: ReleaseManifest = {
+    version: "1.0.0",
+    generatedAt: new Date().toISOString(),
+    fps: options.fps,
+    durationMs: options.durationMs,
+    totalFrames: options.frames.length,
+    seed: options.seed,
+    video: {
+      path: relative(manifestDir, options.videoFile),
+      hash: videoHash,
+      size: videoInfo.size,
+    },
+    frames: frameEntries,
+    plugins: options.plugins,
+    extra: options.extra,
+  };
+  await writeFile(options.outputPath, JSON.stringify(manifest, null, 2), "utf-8");
+  return manifest;
+}
+
+async function collectPngs(dir: string): Promise<string[]> {
+  const files = await readdir(dir);
+  return files
+    .filter((file) => file.toLowerCase().endsWith(".png"))
+    .sort();
+}
+
+async function readPng(path: string): Promise<PNG> {
+  return await new Promise<PNG>((resolve, reject) => {
+    createReadStream(path)
+      .pipe(new PNG())
+      .on("parsed", function (this: PNG) {
+        resolve(this);
+      })
+      .on("error", reject);
+  });
+}
+
+async function writePng(png: PNG, path: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    png
+      .pack()
+      .pipe(createWriteStream(path))
+      .on("finish", resolve)
+      .on("error", reject);
+  });
+}
+
+function inferFramePattern(frames: FrameRenderResult[], outDir: string): string | undefined {
+  const first = frames[0];
+  if (!first) return undefined;
+  const basename = first.path.startsWith(outDir) ? first.path.slice(outDir.length + 1) : relative(outDir, first.path);
+  const match = basename.match(/^(.*?)(\d+)(\.png)$/);
+  if (!match) return undefined;
+  const [, prefix, digits, suffix] = match;
+  return join(outDir, `${prefix}%0${digits.length}d${suffix}`);
+}
+
+async function computeFileHash(path: string, algorithm: string = "sha256"): Promise<string> {
+  const hash = createHash(algorithm);
+  return await new Promise<string>((resolve, reject) => {
+    createReadStream(path)
+      .on("data", (chunk) => hash.update(chunk))
+      .on("error", reject)
+      .on("end", () => resolve(hash.digest("hex")));
+  });
 }

--- a/packages/export/src/types/external.d.ts
+++ b/packages/export/src/types/external.d.ts
@@ -1,0 +1,62 @@
+declare module "fs-extra" {
+  export function mkdirp(path: string): Promise<void>;
+  export function pathExists(path: string): Promise<boolean>;
+}
+
+declare module "pngjs" {
+  import { Duplex } from "stream";
+  import { Buffer } from "buffer";
+  export interface PNGOptions {
+    width?: number;
+    height?: number;
+    fill?: boolean;
+  }
+  export class PNG extends Duplex {
+    constructor(options?: PNGOptions);
+    width: number;
+    height: number;
+    data: Buffer;
+    pack(): NodeJS.ReadableStream;
+    on(event: "parsed", callback: (this: PNG) => void): this;
+    on(event: "error", callback: (error: Error) => void): this;
+  }
+}
+
+declare module "pixelmatch" {
+  import { Buffer } from "buffer";
+  interface PixelmatchOptions {
+    threshold?: number;
+    includeAA?: boolean;
+  }
+  function pixelmatch(
+    img1: Buffer,
+    img2: Buffer,
+    output: Buffer,
+    width: number,
+    height: number,
+    options?: PixelmatchOptions
+  ): number;
+  export = pixelmatch;
+}
+
+declare module "fluent-ffmpeg" {
+  interface FfmpegCommand {
+    setFfmpegPath(path: string): FfmpegCommand;
+    input(input: string): FfmpegCommand;
+    inputOptions(options: string[]): FfmpegCommand;
+    videoCodec(codec: string): FfmpegCommand;
+    outputOptions(options: string[]): FfmpegCommand;
+    output(file: string): FfmpegCommand;
+    on(event: "end", handler: () => void): FfmpegCommand;
+    on(event: "error", handler: (error: Error) => void): FfmpegCommand;
+    run(): void;
+  }
+  function ffmpeg(input?: string): FfmpegCommand;
+  namespace ffmpeg {}
+  export = ffmpeg;
+}
+
+declare module "ffmpeg-static" {
+  const path: string | null;
+  export default path;
+}


### PR DESCRIPTION
## Summary
- guard ffmpeg-static path usage and add explicit error typing for encodeVideo
- provide local type shims for fs-extra, pngjs, pixelmatch, fluent-ffmpeg, and ffmpeg-static so the export bundle can build without external @types packages

## Testing
- npm run build --workspace @vis/export

------
https://chatgpt.com/codex/tasks/task_e_68eacd2945c483279d43453423a360d2